### PR TITLE
更新產品列表頁，產品詳情頁

### DIFF
--- a/src/assets/component/Comment.jsx
+++ b/src/assets/component/Comment.jsx
@@ -1,4 +1,13 @@
+import { useState } from "react"
+
 function Comment() {
+    const [commentExtend, setCommentExtend] = useState(false);
+
+    const handleCommentExtend = () => {
+        setCommentExtend(prevState => !prevState)
+    }
+
+
     return (
         <div className="product">
             <section className="section1 mb-5 pt-8 border-top" id="scrollspyHeading3">
@@ -22,34 +31,34 @@ function Comment() {
                                             <h3 className="fs-5 text-black mb-3">吳*緯</h3>
                                             <div>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
-                                                <span className="material-symbols-outlined text-gray fs-4">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
+                                                <span className="material-symbols-outlined text-gray fs-6 fw-normal">star</span>
                                             </div>
                                         </div>
-                                        <p>我最近開始注重飲食健康，發現這產品非常適合我的需求。高蛋白、低脂肪的特性讓我可以安心享用。</p>
+                                        <p className="fs-6 fw-normal">我最近開始注重飲食健康，發現這產品非常適合我的需求。高蛋白、低脂肪的特性讓我可以安心享用。</p>
                                     </div>
                                     <div className="bg-secondary-200 py-5 border-bottom">
                                         <div className="mb-4 d-flex flex-column">
                                             <h3 className="fs-5 text-black mb-3">莊*玫</h3>
                                             <div>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
-                                                <span className="material-symbols-outlined text-gray fs-4">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
+                                                <span className="material-symbols-outlined text-gray fs-6 fw-normal">star</span>
                                             </div>
                                         </div>
-                                        <p>口感更是令人驚艷。
+                                        <p className="fs-6 fw-normal">口感更是令人驚艷。
                                         </p>
                                     </div>
                                     <div className="bg-secondary-200 py-5 border-bottom">
@@ -57,17 +66,17 @@ function Comment() {
                                             <h3 className="fs-5 text-black mb-3">宜蘭黃小姐</h3>
                                             <div>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
-                                                <span className="material-symbols-outlined text-accent fs-4">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
+                                                <span className="material-symbols-outlined text-accent fs-6 fw-normal">star</span>
                                             </div>
                                         </div>
-                                        <p className="fs-lg-6">
+                                        <p className="fs-6 fw-normal">
                                             從市場直接送到餐桌的速度令人滿意。生產環境看起來也相當乾淨，讓我對食材更加放心。</p>
                                     </div>
                                     <div className="bg-secondary-200 py-5 border-bottom">
@@ -75,17 +84,17 @@ function Comment() {
                                             <h3 className="fs-5 text-black mb-3">顏先生</h3>
                                             <div>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
-                                                <span className="material-symbols-outlined text-accent fs-4">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
+                                                <span className="material-symbols-outlined text-accent fs-6 fw-normal">star</span>
                                             </div>
                                         </div>
-                                        <p>每天當正餐吃，非常美味
+                                        <p className="fs-6 fw-normal">每天當正餐吃，非常美味
                                         </p>
                                     </div>
                                     <div className="bg-secondary-200 py-5 border-bottom">
@@ -93,34 +102,34 @@ function Comment() {
                                             <h3 className="fs-5 text-black mb-3">黃**</h3>
                                             <div>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
-                                                <span className="material-symbols-outlined text-accent fs-4">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
+                                                <span className="material-symbols-outlined text-accent fs-6 fw-normal">star</span>
                                             </div>
                                         </div>
-                                        <p>送貨快速商品品質很好</p>
+                                        <p className="fs-6 fw-normal">送貨快速商品品質很好</p>
                                     </div>
                                     <div className="bg-secondary-200 py-5 border-bottom">
                                         <div className="mb-4 d-flex flex-column">
                                             <h3 className="fs-5 text-black mb-3">J******N</h3>
                                             <div>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
                                                 <span
-                                                    className="material-symbols-outlined text-accent fs-4 me-1">star</span>
-                                                <span className="material-symbols-outlined text-accent fs-4">star</span>
+                                                    className="material-symbols-outlined text-accent fs-6 fw-normal me-1">star</span>
+                                                <span className="material-symbols-outlined text-accent fs-6 fw-normal">star</span>
                                             </div>
                                         </div>
-                                        <p>我對飲食很講究，尤其注重健康，聽說這個品後，決定試試看。果然不負期待，健康美味，值得推薦！
+                                        <p className="fs-6 fw-normal">我對飲食很講究，尤其注重健康，聽說這個品後，決定試試看。果然不負期待，健康美味，值得推薦！
                                         </p>
                                     </div>
                                 </div>
@@ -134,16 +143,16 @@ function Comment() {
                             <div className="card-title mb-lg-4 d-flex flex-lg-column justify-content-between">
                                 <h3 className="fs-6 fs-lg-5 text-black mb-lg-3">吳*緯</h3>
                                 <div>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-gray fs-6 fs-lg-4">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6 fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6 fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6 fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6 fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-gray fs-6 fw-normal fs-lg-4">star</span>
                                 </div>
                             </div>
-                            <p className="card-text fs-7 text-truncate d-lg-none">
+                            <p className="card-text fs-6 fw-normal text-truncate d-lg-none">
                                 我最近開始注重飲食健康，發現這產品非常適合我的需求。高蛋白、低脂肪的特性讓我可以安心享用。</p>
-                            <p className="card-text fs-6 d-none d-lg-block">
+                            <p className="card-text fs-6 fw-normal d-none d-lg-block">
                                 我最近開始注重飲食健康，發現這產品非常適合我的需求。高蛋白、低脂肪的特性讓我可以安心享用。</p>
                             <a href="#" className="mt-auto fs-7 link-primary" data-bs-toggle="modal"
                                 data-bs-target="#model3">看全部</a>
@@ -159,7 +168,7 @@ function Comment() {
                                             <span className="material-symbols-outlined text-accent fs-5 me-1">star</span>
                                             <span className="material-symbols-outlined text-accent fs-5">star</span>
                                         </div>
-                                        <p>我最近開始注重飲食健康，發現這產品非常適合我的需求。高蛋白、低脂肪的特性讓我可以安心享用。</p>
+                                        <p className="fs-6 fw-normal">我最近開始注重飲食健康，發現這產品非常適合我的需求。高蛋白、低脂肪的特性讓我可以安心享用。</p>
                                     </div>
                                 </div>
                             </div>
@@ -170,14 +179,14 @@ function Comment() {
                             <div className="card-title mb-lg-4 d-flex flex-lg-column justify-content-between">
                                 <h3 className="fs-6 fs-lg-5 text-black mb-lg-3">莊*玫</h3>
                                 <div>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-gray fs-6 fs-lg-4">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-gray fs-6  fw-normal fs-lg-4">star</span>
                                 </div>
                             </div>
-                            <p className="card-text fs-7 fs-lg-6">
+                            <p className="card-text fs-6 fw-normal">
                                 口感更是令人驚艷。</p>
                         </div>
                     </div>
@@ -186,16 +195,16 @@ function Comment() {
                             <div className="card-title mb-lg-4 d-flex flex-lg-column justify-content-between">
                                 <h3 className="fs-6 fs-lg-5 text-black mb-lg-3">宜蘭黃小姐</h3>
                                 <div>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4">star</span>
                                 </div>
                             </div>
-                            <p className="card-text fs-7 text-truncate d-lg-none">
+                            <p className="card-text fs-6 fw-normal text-truncate d-lg-none">
                                 從市場直接送到餐桌的速度令人滿意。生產環境看起來也相當乾淨，讓我對食材更加放心。</p>
-                            <p className="card-text fs-6 d-none d-lg-block">
+                            <p className="card-text fs-6 fw-normal d-none d-lg-block">
                                 從市場直接送到餐桌的速度令人滿意。生產環境看起來也相當乾淨，讓我對食材更加放心。</p>
                             <a href="#" className="mt-auto fs-7 link-primary" data-bs-toggle="modal"
                                 data-bs-target="#model2">看全部</a>
@@ -211,7 +220,7 @@ function Comment() {
                                             <span className="material-symbols-outlined text-accent fs-5 me-1">star</span>
                                             <span className="material-symbols-outlined text-accent fs-5">star</span>
                                         </div>
-                                        <p>從市場直接送到餐桌的速度令人滿意。生產環境看起來也相當乾淨，讓我對食材更加放心。</p>
+                                        <p className="fs-6 fw-normal">從市場直接送到餐桌的速度令人滿意。生產環境看起來也相當乾淨，讓我對食材更加放心。</p>
                                     </div>
                                 </div>
                             </div>
@@ -222,72 +231,72 @@ function Comment() {
                             <div className="card-title mb-lg-4 d-flex flex-lg-column justify-content-between">
                                 <h3 className="fs-6 fs-lg-5 text-black mb-lg-3">顏先生</h3>
                                 <div>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                    <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4">star</span>
                                 </div>
                             </div>
-                            <p className="card-text fs-7 fs-lg-6">
+                            <p className="card-text fs-7 fs-6 fw-normal">
                                 每天當正餐吃，非常美味</p>
                         </div>
                     </div>
-                    <p data-bs-toggle="collapse" href="#collapseCommet" role="button" aria-expanded="false"
-                        aria-controls="collapseExample" className="text-primary text-center d-lg-none">看所有評論 (14)</p>
-                    <div className="collapse d-lg-none" id="collapseCommet">
-                        <div className="card border-0 bg-secondary-200 p-4 p-lg-5 mb-2">
-                            <div className="card-title mb-lg-4 d-flex flex-lg-column justify-content-between">
-                                <h3 className="fs-6 fs-lg-5 text-black mb-lg-3">黃**</h3>
-                                <div>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4">star</span>
+                    {commentExtend === true && (
+                        <div>
+                            <div className="card border-0 bg-secondary-200 p-4 p-lg-5 mb-2">
+                                <div className="card-title mb-lg-4 d-flex flex-lg-column justify-content-between">
+                                    <h3 className="fs-6 fs-lg-5 text-black mb-lg-3">黃**</h3>
+                                    <div>
+                                        <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                        <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                        <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                        <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                        <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4">star</span>
+                                    </div>
                                 </div>
+                                <p className="card-text fs-7 fs-6 fw-normal">
+                                    送貨快速商品品質很好</p>
                             </div>
-                            <p className="card-text fs-7 fs-lg-6">
-                                送貨快速商品品質很好</p>
-                        </div>
-                        <div className="card border-0 bg-secondary-200 p-4 p-lg-5">
-                            <div className="card-title mb-lg-4 d-flex flex-lg-column justify-content-between">
-                                <h3 className="fs-6 fs-lg-5 text-black mb-lg-3">J******N</h3>
-                                <div>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4 me-1">star</span>
-                                    <span className="material-symbols-outlined text-accent fs-6 fs-lg-4">star</span>
+                            <div className="card border-0 bg-secondary-200 p-4 p-lg-5">
+                                <div className="card-title mb-lg-4 d-flex flex-lg-column justify-content-between">
+                                    <h3 className="fs-6 fs-lg-5 text-black mb-lg-3">J******N</h3>
+                                    <div>
+                                        <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                        <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                        <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                        <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4 me-1">star</span>
+                                        <span className="material-symbols-outlined text-accent fs-6  fw-normal fs-lg-4">star</span>
+                                    </div>
                                 </div>
-                            </div>
-                            <p className="card-text fs-7 text-truncate d-lg-none">
-                                我對飲食很講究，尤其注重健康，聽說這個品後，決定試試看。果然不負期待，健康美味，值得推薦！
-                            </p>
-                            <p className="card-text fs-lg-6 d-none d-lg-block">
-                                我對飲食很講究，尤其注重健康，聽說這個品後，決定試試看。果然不負期待，健康美味，值得推薦！
-                            </p>
-                            <a href="#" className="mt-auto fs-7 link-primary" data-bs-toggle="modal"
-                                data-bs-target="#model4">看全部</a>
-                            <div className="modal fade" id="model4" tabIndex="-1" aria-labelledby="exampleModalLabel"
-                                aria-hidden="true">
-                                <div className="modal-dialog">
-                                    <div className="modal-content py-5">
-                                        <h3 className="fs-5 text-black mb-3">J******N</h3>
-                                        <div className="mb-4">
-                                            <span className="material-symbols-outlined text-accent fs-5 me-1">star</span>
-                                            <span className="material-symbols-outlined text-accent fs-5 me-1">star</span>
-                                            <span className="material-symbols-outlined text-accent fs-5 me-1">star</span>
-                                            <span className="material-symbols-outlined text-accent fs-5 me-1">star</span>
-                                            <span className="material-symbols-outlined text-accent fs-5">star</span>
+                                <p className="card-text fs-6 fw-normal text-truncate d-lg-none">
+                                    我對飲食很講究，尤其注重健康，聽說這個品後，決定試試看。果然不負期待，健康美味，值得推薦！
+                                </p>
+                                <p className="card-text fs-6 fw-normal d-none d-lg-block">
+                                    我對飲食很講究，尤其注重健康，聽說這個品後，決定試試看。果然不負期待，健康美味，值得推薦！
+                                </p>
+                                <a href="#" className="mt-auto fs-7 link-primary" data-bs-toggle="modal"
+                                    data-bs-target="#model4">看全部</a>
+                                <div className="modal fade" id="model4" tabIndex="-1" aria-labelledby="exampleModalLabel"
+                                    aria-hidden="true">
+                                    <div className="modal-dialog">
+                                        <div className="modal-content py-5">
+                                            <h3 className="fs-5 text-black mb-3">J******N</h3>
+                                            <div className="mb-4">
+                                                <span className="material-symbols-outlined text-accent fs-5 me-1">star</span>
+                                                <span className="material-symbols-outlined text-accent fs-5 me-1">star</span>
+                                                <span className="material-symbols-outlined text-accent fs-5 me-1">star</span>
+                                                <span className="material-symbols-outlined text-accent fs-5 me-1">star</span>
+                                                <span className="material-symbols-outlined text-accent fs-5">star</span>
+                                            </div>
+                                            <p className="fs-6 fw-normal">我對飲食很講究，尤其注重健康，聽說這個品後，決定試試看。果然不負期待，健康美味，值得推薦！
+                                            </p>
                                         </div>
-                                        <p>我對飲食很講究，尤其注重健康，聽說這個品後，決定試試看。果然不負期待，健康美味，值得推薦！
-                                        </p>
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                    </div>
+                        </div>)}
+                    <button type='button' className="btn text-primary text-center d-lg-none border-0 py-1" onClick={handleCommentExtend}>{commentExtend === true ? "收合" : "看所有評論 (14)"}</button>
                 </div>
             </section>
         </div>)

--- a/src/assets/component/Input.jsx
+++ b/src/assets/component/Input.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 function Input({ register, errors, id, labelText, type, rules, mark }) {
     return (
         <div className="mb-3">
-            <label htmlFor={id} className="form-label"><small className="text-accent">{mark}</small>{labelText}</label>
+            <label htmlFor={id} className="form-label"><span className="text-accent">{mark}</span>{labelText}</label>
             <input
                 type={type}
                 className={`form-control ${errors[id] && 'is-invalid'}`}

--- a/src/assets/component/Select.jsx
+++ b/src/assets/component/Select.jsx
@@ -4,7 +4,7 @@ const Select = ({ id, labelText, register, errors, rules, children, disabled = f
     return (
         <div className="mb-3">
             <label htmlFor={id} className='form-label'>
-                <small className="text-accent">{mark}</small>
+                <span className="text-accent">{mark}</span>
                 {labelText}
             </label>
             <select

--- a/src/assets/component/UpdateQtyBtnGroup.jsx
+++ b/src/assets/component/UpdateQtyBtnGroup.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types"
 
-function UpdateQtyBtnGroup({ itemQty, onClickfn1, onClickfn2 }) {
+function UpdateQtyBtnGroup({ itemQty, onClickfn1, onClickfn2, maxQty }) {
     return (
         <div className="me-2">
             <button
@@ -21,6 +21,7 @@ function UpdateQtyBtnGroup({ itemQty, onClickfn1, onClickfn2 }) {
                 className="btn btn-secondary text-primary fs-2 py-0"
                 style={{ width: "48px" }}
                 onClick={onClickfn2}
+                disabled={itemQty >= maxQty}
             >
                 +
             </button>
@@ -30,6 +31,7 @@ function UpdateQtyBtnGroup({ itemQty, onClickfn1, onClickfn2 }) {
 UpdateQtyBtnGroup.propTypes = {
     itemQty: PropTypes.number.isRequired,
     onClickfn1: PropTypes.func.isRequired,
-    onClickfn2: PropTypes.func.isRequired 
+    onClickfn2: PropTypes.func.isRequired,
+    maxQty: PropTypes.number,
 };
 export default UpdateQtyBtnGroup

--- a/src/assets/layout/AutoOnTop.jsx
+++ b/src/assets/layout/AutoOnTop.jsx
@@ -2,14 +2,21 @@ import { useLocation } from "react-router";
 import { useEffect } from "react";
 
 const AutoOnTop = () => {
-    const {pathname} = useLocation();
-    useEffect(()=>{
-        window.scrollTo({
-            top: 0,
-            left: 0,
-            behavior: 'instant'
-        });
-    },[pathname])
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        const segments = pathname.split('/').filter(Boolean);
+
+        const isProductCategoryPage =
+            segments[0] === 'products' && segments.length === 2;
+        if (!isProductCategoryPage) {
+            window.scrollTo({
+                top: 0,
+                left: 0,
+                behavior: 'instant',
+            });
+        }
+    }, [pathname]);
 
     return null;
 }

--- a/src/assets/pages/Home.jsx
+++ b/src/assets/pages/Home.jsx
@@ -227,7 +227,7 @@ function Home() {
                                 >
                                     {filteredProducts.length > 0 ? (
                                         filteredProducts.map((product) => (
-                                            <SwiperSlide key={product.id} className="swiper-slide card border-0">
+                                            <SwiperSlide key={product.id} className="swiper-slide card border-0 home-products-card">
                                                 <div>
                                                     <Link to={`/products/${product.category}/${product.id}`}>
                                                         <img src={product.imageUrl} alt={product.name} className="rounded-4 product-index-img" />

--- a/src/assets/pages/Stories.jsx
+++ b/src/assets/pages/Stories.jsx
@@ -33,7 +33,7 @@ function Stories() {
             />
             {/* <!--故事列表--> */}
             <section>
-                <div className="container position-relative py-lg-11 py-6">
+                <div className="container position-relative py-lg-11 py-4">
                     <img src="images/Illustration/peace.png" alt="peace" className="story-deco1" />
                     {/* <!--文章列表--> */}
                     <div className="row row-cols-1 gy-6 mb-10">

--- a/src/assets/pages/order/ComfirmOrder.jsx
+++ b/src/assets/pages/order/ComfirmOrder.jsx
@@ -20,6 +20,7 @@ function ComfirmOrder() {
     const [addressData, setAddressData] = useState([]);
     const [useCreditCard, setUseCreditCard] = useState(false)
     const [useOtherPay, setUseOtherPay] = useState(false);
+    const [paymentMethod, setPaymentMethod] = useState("linePay");
     const [couponCode, setCouponCode] = useState('');
     const [shippingType, setShippingType] = useState('normal');
     const [orderExtend, setOrderExtend] = useState(false);
@@ -442,11 +443,15 @@ function ComfirmOrder() {
                     </div>
                     {/* 付款方式 */}
                     <div className="card bg-white mb-3 p-5 border-primary" style={{ borderRadius: "16px" }}>
-                        <div className="card-title text-primary fs-5 fs-lg-4 mb-6">付款方式<small className="fs-7 text-dark ms-2">(未啟用)</small></div>
+                        <div className="card-title text-primary fs-5 fs-lg-4 mb-6">付款方式</div>
                         <div className="mt-5">
                             <div className="form-check">
-                                <input className="form-check-input me-4" type="radio" name="flexRadioDefault2" id="creditCard" onClick={handleUseCreditCard} />
-                                <label className="form-check-label fs-lg-5 fs-6" htmlFor="flexRadioDefault2" >
+                                <input className="form-check-input me-4" type="radio" name="flexRadioDefault2" id="creditCard" onChange={() => {
+                                    setPaymentMethod("creditCard");
+                                    handleUseCreditCard();
+                                }}
+                                    checked={paymentMethod === "creditCard"} />
+                                <label className="form-check-label fs-lg-5 fs-6" htmlFor="creditCard" >
                                     信用卡付款
                                 </label>
                             </div>
@@ -494,22 +499,32 @@ function ComfirmOrder() {
 
 
                             <div className="form-check mt-5">
-                                <input className="form-check-input me-4" type="radio" name="flexRadioDefault2" id="linePay" onClick={handleOtherPay} />
-                                <label className="form-check-label fs-lg-5 fs-6 en-font" htmlFor="flexRadioDefault2">
+                                <input className="form-check-input me-4" type="radio" name="flexRadioDefault2" id="linePay" onChange={() => {
+                                    setPaymentMethod("linePay");
+                                    handleOtherPay();
+                                }}
+                                    checked={paymentMethod === "linePay"} />
+                                <label className="form-check-label fs-lg-5 fs-6 en-font" htmlFor="linePay">
                                     <img src="images/icon/linepay.png" alt="applepay" height="24px" className="me-3" />
                                     Line Pay
                                 </label>
                             </div>
                             <div className="form-check mt-5">
-                                <input className="form-check-input me-4" type="radio" name="flexRadioDefault2" id="applePay" onClick={handleOtherPay} />
-                                <label className="form-check-label fs-lg-5 fs-6 en-font" htmlFor="flexRadioDefault2">
+                                <input className="form-check-input me-4" type="radio" name="flexRadioDefault2" id="applePay" onChange={() => {
+                                    setPaymentMethod("applePay");
+                                    handleOtherPay();
+                                }} />
+                                <label className="form-check-label fs-lg-5 fs-6 en-font" htmlFor="applePay">
                                     <img src="images/icon/applepay.png" alt="applepay" height="24px" className="me-3" />
                                     Apple Pay
                                 </label>
                             </div>
                             <div className="form-check mt-5">
-                                <input className="form-check-input me-4" type="radio" name="flexRadioDefault" id="googlePay" onClick={handleOtherPay} />
-                                <label className="form-check-label fs-lg-5 fs-6 en-font" htmlFor="flexRadioDefault2">
+                                <input className="form-check-input me-4" type="radio" name="flexRadioDefault" id="googlePay" onChange={() => {
+                                    setPaymentMethod("googlePay");
+                                    handleOtherPay();
+                                }} />
+                                <label className="form-check-label fs-lg-5 fs-6 en-font" htmlFor="googlePay">
                                     <img src="images/icon/googlepay.png" alt="applepay" height="24px" className="me-3" />
                                     Google Pay
                                 </label>

--- a/src/assets/pages/product/ProductBrowsingHistory.jsx
+++ b/src/assets/pages/product/ProductBrowsingHistory.jsx
@@ -1,31 +1,26 @@
 import { Link } from "react-router"
 import PropTypes from "prop-types"
 
-function ProductBrowsingHistory({ recentProducts }) {
+function ProductBrowsingHistory({ recentProducts = [] }) {
     return (<>
         {/* 電腦版 */}
         <div className="w-lg-100 h-lg-auto my-lg-7 mt-5 p-lg-5 pb-lg-0 pt-5 px-4 pb-0 allProduct-side-history d-none d-lg-block">
-            <h6 className="fs-5 mb-4 text-">你曾瀏覽過：</h6>
-            <div className="d-lg-block d-flex flex-nowrap">
-                {
-                    recentProducts.length > 0 ? (
-                        recentProducts.map((product) => (
-                            <div className="me-lg-0 me-3" key={product.id}>
-                                <Link to={`/products/${product.category}/${product.id}`}>
-                                    <img src={product.imageUrl} alt={product.title} />
-                                    <div className="card-body p-2">
-                                        <h5>{product.title}</h5>
-                                    </div>
-                                </Link>
-                            </div>
-                        ))
-                    ) : (
-                        <p className="text-center">還沒有瀏覽紀錄</p>
-                    )
-                }
-            </div>
+            {recentProducts.length > 0 && (<>
+                <h6 className="fs-5 mb-4 text-">你曾瀏覽過：</h6>
+                <div className="d-lg-block d-flex flex-nowrap">
+                    {recentProducts.map((product) => (
+                        <div className="me-lg-0 me-3" key={product.id}>
+                            <Link to={`/products/${product.category}/${product.id}`}>
+                                <img src={product.imageUrl} alt={product.title} />
+                                <div className="card-body p-2">
+                                    <h5>{product.title}</h5>
+                                </div>
+                            </Link>
+                        </div>
+                    ))}
+                </div>
+            </>)}
         </div>
-
     </>
     )
 }
@@ -41,7 +36,4 @@ ProductBrowsingHistory.propTypes = {
 };
 
 
-ProductBrowsingHistory.defaultProps = {
-    recentProducts: [],
-};
 export default ProductBrowsingHistory

--- a/src/assets/pages/product/ProductListAll.jsx
+++ b/src/assets/pages/product/ProductListAll.jsx
@@ -120,7 +120,7 @@ function ProductListAll() {
                         {categories.map((category) => {
                             return (<div className="accordion-item" key={category}>
                                 <h2 className="accordion-header" id="headingTwo">
-                                    <button type="button" className={`accordion-button px-0 fw-bold fs-4 ${selectCategory === category ? "text-primary collapsed" : "text-dark"}`} onClick={() => handleCategoryChange(category)}>
+                                    <button type="button" className={`btn px-0 fw-bold fs-4 ${selectCategory === category ? "text-primary collapsed" : "text-dark"}`} onClick={() => handleCategoryChange(category)}>
                                         {category}
                                     </button>
                                 </h2>
@@ -167,11 +167,11 @@ function ProductListAll() {
                         {filterProducts.length > 0 ? (
                             filterProducts.map((product) => (
                                 <div className="col-xl-4 col-lg-6 col-md-4 " key={product.id}>
-                                    <Link className="card my-5 allProduct-catalog-card d-flex flex-md-column flex-row"
+                                    <Link className="card my-5 allProduct-catalog-card d-flex flex-md-column flex-row pb-4"
                                         to={`/products/${product.category}/${product.id}`}
                                         onClick={() => handleViewProduct(product)}>
                                         <img src={product.imageUrl} className="card-img-top allProduct-catalog-img" alt={product.title} />
-                                        <div className="card-body py-0 px-md-0 ps-5 pe-0">
+                                        <div className="card-body py-0 px-md-3 ps-5 pe-0">
                                             <h5 className="card-title mt-md-3 mt-0 mb-md-4 mb-2 fs-5">{product.title}</h5>
                                             <p className="text-accent fs-5">
                                                 {`NT$${product.price}`}

--- a/src/assets/pages/product/ProductMobileHistory.jsx
+++ b/src/assets/pages/product/ProductMobileHistory.jsx
@@ -3,31 +3,28 @@ import { Link } from 'react-router';
 import 'swiper/css';
 import PropTypes from "prop-types";
 
-function ProductMobileHistory({ recentProducts=[] }) {
+function ProductMobileHistory({ recentProducts = [] }) {
     return (
         // 手機板
         <div className="d-lg-none d-block container">
-            <h6 className="fs-5 mb-4 ">你曾瀏覽過：</h6>
-            <Swiper
-                spaceBetween={12}
-                slidesPerView={2.1}>
-                {
-                    recentProducts.length > 0 ? (
-                        recentProducts.map((product) => (
-                            <SwiperSlide key={product.id}>
-                                <Link to={`/products/${product.category}/${product.id}`}>
-                                    <img src={product.imageUrl} alt={product.title} width="150px" height="150px" className="object-fit-cover" style={{borderRadius:"16px"}}/>
-                                    <div className="card-body p-2">
-                                        <h5>{product.title}</h5>
-                                    </div>
-                                </Link>
-                            </SwiperSlide>
-                        ))
-                    ) : (
-                        <p className="text-center">還沒有瀏覽紀錄</p>
-                    )
-                }
-            </Swiper>
+            {recentProducts.length > 0 && (<>
+                <h6 className="fs-5 mb-4 ">你曾瀏覽過：</h6>
+                <Swiper
+                    spaceBetween={12}
+                    slidesPerView={2.1}>
+                    {recentProducts.map((product) => (
+                        <SwiperSlide key={product.id}>
+                            <Link to={`/products/${product.category}/${product.id}`}>
+                                <img src={product.imageUrl} alt={product.title} width="150px" height="150px" className="object-fit-cover" style={{ borderRadius: "16px" }} />
+                                <div className="card-body p-2">
+                                    <h5>{product.title}</h5>
+                                </div>
+                            </Link>
+                        </SwiperSlide>
+                    ))}
+                </Swiper>
+            </>)}
+
         </div>
     )
 }
@@ -42,8 +39,5 @@ ProductMobileHistory.propTypes = {
     ),
 };
 
-// ✅ 預設 props，避免 undefined 問題
-ProductMobileHistory.defaultProps = {
-    recentProducts: [],
-};
+
 export default ProductMobileHistory

--- a/src/assets/scss/pages/_allProduct.scss
+++ b/src/assets/scss/pages/_allProduct.scss
@@ -154,10 +154,14 @@
     &-img {
 
         object-fit: cover;
-        border-radius: 1rem;
+        border-top-left-radius: 1rem;
+        border-top-right-radius: 1rem;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
         aspect-ratio: 306/280;
+
         @media (max-width: 992px) {
-            
+
             width: 150px;
 
         }
@@ -165,6 +169,31 @@
 
     &-card {
         border: none;
+        border-radius: 1rem;
+        transition: all 0.3s ease;
+
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(255, 255, 255, 0.3);
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: none;
+            z-index: 1;
+        }
+
+        &:hover::before {
+            opacity: 1;
+        }
+
+        &:hover {
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+            transform: translateY(-4px);
+        }
     }
 }
 
@@ -192,7 +221,8 @@
     min-height: 228px;
     object-fit: cover;
 }
-.slide-image{
+
+.slide-image {
     width: 150px;
     height: 150px;
     border-radius: 16px;

--- a/src/assets/scss/pages/_index.scss
+++ b/src/assets/scss/pages/_index.scss
@@ -331,3 +331,23 @@ body {
         max-width: 120px;
     }
 }
+
+// 產品hover
+.home-products-card{
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(255, 255, 255, 0.3); 
+        opacity: 0;
+        transition: opacity 0.3s ease;
+        pointer-events: none; 
+        z-index: 1;
+    }
+    &:hover::before {
+        opacity: 1;
+    }
+}

--- a/src/assets/scss/pages/_product.scss
+++ b/src/assets/scss/pages/_product.scss
@@ -44,13 +44,18 @@
             object-fit: cover;
         }
 
-        .border-bottom-transparent {
-            font-weight: bold;
+        .tab-button {
+            color: black;
+            border: none;
 
-            &.active,
             &:hover {
-                border-bottom: 4px solid $primary;
                 color: $primary;
+                border-bottom: 4px solid $primary;
+            }
+
+            &.active {
+                color: $primary;
+                border-bottom: 4px solid $primary;
             }
         }
 
@@ -77,6 +82,7 @@
         .text-content {
             max-height: 200px;
         }
+
         .text-extend {
             max-height: auto;
         }


### PR DESCRIPTION
更新以下
前台

-產品列表頁：目前點擊分類後都會滾動到頁面最上方，使用者需要重新向下捲動觀看產品列表，可以嘗試點擊後直接定位在產品區塊，便於使用者瀏覽


-產品詳情頁
產品的購買數量可以加入驗證，避免超過產品剩餘庫存
點擊 tab 時建議調整成會出現對應資訊
-產品成功加入購物車可以補上操作成功、錯誤提示回饋


-訂單確認表單：建議付款方式也加入必填驗證，或是預設選擇某一選項

設計師針對畫面的修改建議:
產品頁｜
產品列表
-建議將「全部商品」的下拉 icon 移除，避免使用者誤以為還能點擊打開更多選單
-目前點擊左側選單的商品分類後並沒有顯示子分類，如果沒有子分類的話一樣建議移除下拉 icon 唷
-如果沒有瀏覽紀錄的話可以先不顯示「你曾瀏覽過：」
-產品卡片建議可以做出 Hover 的樣式


產品詳情頁
-產品名稱是是本頁重要資訊之一，字級建議可以使用 32px
-規格與數量的字級建議使用 Ch-Text-Body2（16px, font-weight 400）
-按鈕文字在 Hover 狀態下使用白色的話對比度會偏低，建議使用強調色 #FF8965
-Tab 建議做出 Active 樣式，提示使用者當前在閱覽哪一個 Tab
-切換 Tab 後應顯示對應內容，目前顯示的內容都是同一個哦！
-商品介紹的內文字級建議使用 Ch-Text-Body2（16px, font-weight 400）
-評論卡片的內文建議統一使用 Ch-Text-Body2（16px, font-weight 400）