### PR TITLE
刪除alert,修正產地故事頁

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,17 +1,34 @@
 <!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/LOGOicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>彰源鮮味</title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
-    <link href="/path/to/c3.css" rel="stylesheet">
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+<html lang="zh-Hant-TW">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/LOGOicon.png" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="author" content="彰源鮮味" />
+  <meta name="description" content="來自彰化的新鮮美味、在地農夫精心栽培，每一口都是健康的保證。" />
+  <meta name="keywords" content="在地小農, 產地直送, 環境永續, 無添加" />
+  <title>彰源鮮味</title>
+
+  <meta property="og:title" content="在地農夫精心栽培，每一口都是健康的保證。" />
+  <meta property="og:description" content="來自彰化的新鮮美味、在地農夫精心栽培，每一口都是健康的保證。" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://changyuan-fresh.github.io/react/" />
+  <meta property="og:image" content="https://changyuan-fresh.github.io/react/assets/LOGO-L-CGOeF4Ap.png" />
+  <meta property="og:site_name" content="彰源鮮味" />
+  <meta name="theme-color" content="#788F49" />
+  <link rel="apple-touch-icon" href="/LOGOicon.png" />
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+  <link href="/path/to/c3.css" rel="stylesheet">
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+
 </html>

--- a/src/assets/component/DeleteCartModal.jsx
+++ b/src/assets/component/DeleteCartModal.jsx
@@ -29,7 +29,7 @@ function DeleteCartModal({ getCartList, delModelRef }) {
             const res = await axios.delete(`${baseUrl}/v2/api/${apiPath}/carts`)
             dispatch(createAsyncMessage({
                 text: res.data.message,
-                type: '刪除產品成功',
+                type: '清空購物車成功',
                 status: "success"
             }));
             getCartList()
@@ -37,7 +37,7 @@ function DeleteCartModal({ getCartList, delModelRef }) {
             const { message } = error.response.data;
             dispatch(createAsyncMessage({
                 text: message.join("、"),
-                type: '刪除產品失敗',
+                type: '清空購物車失敗',
                 status: "failed"
             }));
         } finally {
@@ -57,7 +57,7 @@ function DeleteCartModal({ getCartList, delModelRef }) {
                     </div>
                     <div className="modal-footer">
                         <button type="button" className="btn btn-secondary px-6" onClick={closeDelModal}>取消</button>
-                        <button type="button" className="btn btn-accent px-6 text-white" onClick={removeCart}>刪除</button>
+                        <button type="button" className="btn btn-accent px-6 text-white" onClick={removeCart}>清空</button>
                     </div>
                 </div>
             </div>

--- a/src/assets/component/Input.jsx
+++ b/src/assets/component/Input.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types"
 
-function Input({ register, errors, id, labelText, type, rules, mark }) {
+function Input({ register, errors = {}, id, labelText, type = "text", rules = {}, mark }) {
     return (
         <div className="mb-3">
             <label htmlFor={id} className="form-label"><span className="text-accent">{mark}</span>{labelText}</label>
@@ -27,10 +27,5 @@ Input.propTypes = {
     mark: PropTypes.string
 };
 
-Input.defaultProps = {
-    type: "text",
-    errors: {},
-    rules: {}
-};
 
 export default Input

--- a/src/assets/component/ProductModal.jsx
+++ b/src/assets/component/ProductModal.jsx
@@ -100,8 +100,18 @@ function ProductModal({ modalMode, tempProduct, getProductList, setTempProduct, 
                 ...tempProduct,
                 imageUrl: upLoadImgUrl
             })
+            dispatch(createAsyncMessage({
+                text: '上傳圖片成功',
+                type: '成功',
+                status: "success"
+            }))
         } catch (error) {
-            alert(error.response.data.message)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '上傳圖片失敗',
+                status: "failed"
+            }))
         } finally {
             e.target.value = "";
         }

--- a/src/assets/component/StoryModal.jsx
+++ b/src/assets/component/StoryModal.jsx
@@ -94,8 +94,17 @@ function StoryModal({ modalMode, tempArticle, getArticleList, setTempArticle, mo
                 ...tempArticle,
                 image: upLoadImg
             })
+            dispatch(createAsyncMessage({
+                text: '上傳圖片成功',
+                type: '成功',
+                status: "success"
+            }))
         } catch (error) {
-            alert(error.response.data.message)
+            dispatch(createAsyncMessage({
+                text: message.join("、"),
+                type: '上傳圖片失敗',
+                status: "failed"
+            }));
         } finally {
             e.target.value = "";
         }

--- a/src/assets/component/UpdateQtyBtnGroup.jsx
+++ b/src/assets/component/UpdateQtyBtnGroup.jsx
@@ -2,15 +2,15 @@ import PropTypes from "prop-types"
 
 function UpdateQtyBtnGroup({ itemQty, onClickfn1, onClickfn2, maxQty }) {
     return (
-        <div className="me-2">
+        <div className="me-2 d-flex">
             <button
                 type="button"
-                className="btn btn-secondary text-primary fs-2 py-0"
-                style={{ width: "48px" }}
+                className="btn btn-secondary text-primary fs-2 d-flex align-items-center justify-content-center"
+                style={{ width: "48px", height: "48px" }}
                 onClick={onClickfn1}
                 disabled={itemQty === 1}
             >
-                -
+                <span className="material-symbols-outlined">remove</span>
             </button>
             <button
                 className="btn border border-primary mx-2 py-0"
@@ -18,12 +18,12 @@ function UpdateQtyBtnGroup({ itemQty, onClickfn1, onClickfn2, maxQty }) {
             >{itemQty}</button>
             <button
                 type="button"
-                className="btn btn-secondary text-primary fs-2 py-0"
-                style={{ width: "48px" }}
+                className="btn btn-secondary text-primary fs-2 d-flex align-items-center justify-content-center"
+                style={{ width: "48px", height: "48px" }}
                 onClick={onClickfn2}
                 disabled={itemQty >= maxQty}
             >
-                +
+                <span className="material-symbols-outlined">add</span>
             </button>
         </div>)
 }

--- a/src/assets/layout/AdminLayout.jsx
+++ b/src/assets/layout/AdminLayout.jsx
@@ -2,19 +2,30 @@ import { Outlet, useNavigate } from "react-router-dom";
 import AdminSidebar from "./AdminSidebar";
 import AdminNavbar from "./AdminNavbar";
 import { useCallback, useEffect } from "react";
+import { useDispatch } from 'react-redux';
 import axios from 'axios';
 import Toast from "./Toast";
+import { createAsyncMessage } from "../redux/slice/toastSlice";
+
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
 
 
 function AdminLayout() {
     const navigate = useNavigate();
+    const dispatch = useDispatch();
+
+
     const checkLogin = useCallback(async () => {
         try {
             await axios.post(`${baseUrl}/v2/api/user/check`);
         } catch (error) {
-            alert("請登入管理員帳號", error.response);
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '請登入管理員帳號',
+                status: "failed"
+            }))
             navigate('/adminlogin');
         }
     }, [navigate]);

--- a/src/assets/layout/AdminSidebar.jsx
+++ b/src/assets/layout/AdminSidebar.jsx
@@ -24,7 +24,12 @@ function AdminSidebar() {
                 status: "success"
             }));
         } catch (error) {
-            alert("登出失敗");
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '登出失敗',
+                status: "failed"
+            }))
         }
     };
 

--- a/src/assets/layout/Navbar.jsx
+++ b/src/assets/layout/Navbar.jsx
@@ -5,6 +5,7 @@ import axios from 'axios'
 import logoS from '../images/LOGO-S.png';
 import logoL from '../images/LOGO-L.png';
 import { updateCartData } from '../redux/slice/cartSlice'
+import { createAsyncMessage } from "../redux/slice/toastSlice";
 
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
@@ -14,6 +15,7 @@ function Navbar() {
     const cartNum = useSelector(state => state.cart.carts);
     const dispatch = useDispatch();
     const [isOpen, setIsOpen] = useState(false);
+    
 
     // 當用戶點擊導航連結時，將折疊區域關閉
     const handleLinkClick = () => {
@@ -30,7 +32,12 @@ function Navbar() {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/cart`);
             dispatch(updateCartData(res.data.data));
         } catch (error) {
-            alert(error.response);
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得購物車資訊失敗',
+                status: "failed"
+            }))
         }
     }, [dispatch]); // 只在 dispatch 變更時重新創建
 
@@ -40,7 +47,7 @@ function Navbar() {
 
 
     return (<>
-        <header className="navbar navbar-expand-lg p-0 bg-white">
+        <header className="navbar navbar-expand-lg p-0 bg-white sticky-top">
             <div className="container-fluid py-4 px-3">
                 <NavLink className="navbar-brand" to='/'>
                     <picture>

--- a/src/assets/layout/Toast.jsx
+++ b/src/assets/layout/Toast.jsx
@@ -1,19 +1,19 @@
 import { useSelector } from "react-redux"
 
 function Toast() {
-    const messages = useSelector((state) =>{
+    const messages = useSelector((state) => {
         return state.toast
     })
     return (
-        <div className="position-fixed top-0 end-0 p-3" style={{ zIndex: 1000 }}>
+        <div className="p-3" style={{ zIndex: 1000, position: "fixed", top: "150px", right: 0 }}>
             {messages.map((message) => {
                 return (
-                    <div 
-                    key={message.id}
-                    className="toast show bg-white" 
-                    role="alert" 
-                    aria-live="assertive" 
-                    aria-atomic="true">
+                    <div
+                        key={message.id}
+                        className="toast show bg-white"
+                        role="alert"
+                        aria-live="assertive"
+                        aria-atomic="true">
                         <div className={`toast-header text-white ${message.status === "success" ? "bg-primary" : "bg-accent"}`}>
                             <strong className="me-auto">{message.type}</strong>
                             <button

--- a/src/assets/pages/ProductDetail.jsx
+++ b/src/assets/pages/ProductDetail.jsx
@@ -42,23 +42,28 @@ function ProductDetail() {
             });
             navigate("/cart")
         } catch (error) {
-            alert(error.data.message)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得資料失敗',
+                status: "failed"
+            }))
         }
     }
 
     const addCartItem = async (product_id, qtySelect) => {
         setIsLoadingBtn(true);
         setIsLoading(true);
-        
+
         if (qtySelect > product.product_stock) {
             dispatch(createAsyncMessage({
                 text: '所選數量超過庫存',
                 type: '庫存不足',
                 status: "failed"
             }));
-            return; // 直接停止执行
+            return;
         }
-    
+
         try {
             const res = await axios.post(`${baseUrl}/v2/api/${apiPath}/cart`, {
                 data: {
@@ -96,7 +101,12 @@ function ProductDetail() {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/product/${product_id}`);
             setProduct(res.data.product);
         } catch (error) {
-            alert('取得資料失敗', error.response);
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得資料失敗',
+                status: "failed"
+            }))
         } finally {
             setIsLoading(false);
         }
@@ -113,7 +123,12 @@ function ProductDetail() {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/cart`);
             dispatch(updateCartData(res.data.data));
         } catch (error) {
-            alert(error.data);
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得資料失敗',
+                status: "failed"
+            }))
         }
     }, [dispatch]);
     useEffect(() => {

--- a/src/assets/pages/Stories.jsx
+++ b/src/assets/pages/Stories.jsx
@@ -1,26 +1,36 @@
 import { Link } from 'react-router';
 import { useEffect, useState } from "react";
+import { useDispatch } from 'react-redux';
 import axios from 'axios'
 import Banner from "../layout/Banner";
+import Toast from '../layout/Toast';
+import { createAsyncMessage } from '../redux/slice/toastSlice';
+
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
 const apiPath = import.meta.env.VITE_API_PATH;
 
 function Stories() {
     const [stories, setStories] = useState([]);
+    const dispatch = useDispatch();
 
-    const getStoryList = async()=>{
+    const getStoryList = async () => {
         try {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/articles`);
             setStories(res.data.articles);
         } catch (error) {
-            alert('取得文章失敗', error.data.message)
-        } 
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得文章失敗',
+                status: "failed"
+            }))
+        }
     }
 
-    useEffect(()=>{
+    useEffect(() => {
         getStoryList();
-    },[])
+    }, [])
 
     return (<>
         <main>
@@ -37,34 +47,43 @@ function Stories() {
                     <img src="images/Illustration/peace.png" alt="peace" className="story-deco1" />
                     {/* <!--文章列表--> */}
                     <div className="row row-cols-1 gy-6 mb-10">
-                        {stories.map((story)=>{
+                        {stories.map((story) => {
                             return (
-                            <div className="col" key={story.id}>
-                                <div className="card story-card d-flex flex-lg-row flex-column border-0 rounded-4 bg-secondary-200 p-5 w-100">
-                                    <img src={story.image} alt={story.title} className="rounded-4" />
-                                    <div className="card-body d-flex flex-column justify-content-between px-lg-4 px-0 py-lg-0 pt-4 pb-0 w-50">
-                                        <div>
-                                            <div className="d-flex justify-content-between align-items-baseline ">
-                                                <h6 className="card-title fs-lg-2  fs-md-4 fs-sm-5 text-primary text-nowrap">{story.title}</h6>
-                                                <p className="card-text text-gray d-none d-lg-block"><small>{new Date(story.create_at).toLocaleDateString()}</small></p>
+                                <div className="col" key={story.id}>
+                                    <div className="card story-card d-flex flex-lg-row flex-column border-0 rounded-4 bg-secondary-200 p-5 w-100">
+                                        <img src={story.image} alt={story.title} className="rounded-4" />
+                                        <div className="card-body d-flex flex-column justify-content-between px-lg-4 px-0 py-lg-0 pt-4 pb-0 w-50">
+                                            <div>
+                                                <div className="d-flex justify-content-between align-items-baseline ">
+                                                    <h4 className="card-title fs-md-4 fs-5 text-primary text-nowrap mb-2 mb-lg-0">{story.title}</h4>
+                                                    <p className="card-text text-gray d-none d-lg-block"><small className="fw-normal">{new Date(story.create_at).toLocaleDateString()}</small></p>
+                                                </div>
+                                                {story.description
+                                                    ?.replace(/<\/?br\s*\/?>/gi, '<br/><br/>') 
+                                                    .split(/<br\s*\/?>\s*<br\s*\/?>/gi)   
+                                                    .filter(line => line.trim() !== '')
+                                                    .map((line, idx) => (
+                                                        <p key={idx} className="card-text fs-lg-6 fw-normal d-lg-block d-none">
+                                                            {line.trim()}
+                                                        </p>
+                                                    ))}
                                             </div>
-                                            <p className="card-text fs-lg-5 d-lg-block d-none">{story.description}</p>
+                                            <div className="d-lg-flex justify-content-end d-none">
+                                                <Link className="btn text-accent fw-bolder fs-3 d-flex align-items-center" to={`/stories/${story.id}`}>看更多<span className="material-symbols-outlined align-middle fs-4">chevron_right</span></Link>
+                                            </div>
                                         </div>
-                                        <div className="d-lg-flex justify-content-end d-none">
-                                            <Link className="btn text-accent fw-bolder fs-3" to={`/stories/${story.id}`}>More<span className="material-symbols-outlined align-middle">chevron_right</span></Link>
-                                        </div>
+                                        <Link to={`/stories/${story.id}`}><p className="card-text text-accent fw-bolder d-lg-none d-block ">More<span className="material-symbols-outlined align-middle">chevron_right</span></p>
+                                        </Link>
                                     </div>
-                                    <Link to={`/stories/${story.id}`}><p className="card-text text-accent fw-bolder d-lg-none d-block ">More<span className="material-symbols-outlined align-middle">chevron_right</span></p>
-                                    </Link>
-                                </div>
-                            </div>)
+                                </div>)
                         })}
-                        
+
                     </div>
                     <img src="images/Illustration/house.png" alt="house" className="story-deco2" />
                 </div>
             </section>
         </main>
+        <Toast />
     </>
     )
 }

--- a/src/assets/pages/Story.jsx
+++ b/src/assets/pages/Story.jsx
@@ -1,8 +1,11 @@
 import { useCallback, useState, useEffect } from "react";
 import { Link, useParams } from "react-router";
+import { useDispatch } from 'react-redux';
 import axios from 'axios'
 import Banner from "../layout/Banner";
 import IsScreenLoading from "../component/IsScreenLoading";
+import Toast from "../layout/Toast";
+import { createAsyncMessage } from "../redux/slice/toastSlice";
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
 const apiPath = import.meta.env.VITE_API_PATH;
@@ -12,13 +15,19 @@ function Story() {
     const [story, setStory] = useState({})
     const { id: story_id } = useParams();
     const [isScreenLoading, setIsScreenLoading] = useState(false)
+    const dispatch = useDispatch();
 
     const getStoryList = useCallback(async () => {
         try {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/articles`);
             setStories(res.data.articles);
         } catch (error) {
-            alert('取得文章失敗', error.data.message)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得文章失敗',
+                status: "failed"
+            }))
         }
     }, []);
 
@@ -28,7 +37,12 @@ function Story() {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/article/${story_id}`);
             setStory(res.data.article);
         } catch (error) {
-            alert('取得文章失敗', error.data.message)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得文章失敗',
+                status: "failed"
+            }))
         } finally {
             setIsScreenLoading(false)
         }
@@ -55,20 +69,21 @@ function Story() {
                     <article className="story-article bg-secondary-200 p-lg-7 p-5 rounded-3 mb-5 mb-lg-0">
                         <div className="d-sm-flex justify-content-between align-items-baseline mb-lg-5 mb-3">
                             <h4 className="fs-lg-1 fs-md-3 text-nowrap">{story.title}</h4>
-                            <p className="text-gray fs-7" >{new Date(story.create_at).toLocaleDateString()}</p>
+                            <p className="text-gray fs-7 fw-normal" >{new Date(story.create_at).toLocaleDateString()}</p>
                         </div>
                         <p dangerouslySetInnerHTML={{ __html: story.description }}></p>
                         <img src={story.image} className="img-fluid story-cauliflower-img" />
                         <p dangerouslySetInnerHTML={{ __html: story.content }}></p>
                         <img src={story.image2} className="img-fluid story-cauliflower-img" />
                     </article>
-                    <aside className="ms-lg-5 mb-8 mb-lg-5 sticky-lg-top ">
-                        <div className="list-group list-group-flush p-5 bg-secondary rounded-3 sticky-top ">
+                    <aside className="ms-lg-5 mb-8 mb-lg-5">
+                        <div className="list-group list-group-flush p-5 bg-secondary rounded-3" style={{ position: 'sticky', top: '130px' }}>
                             <Link className="story-cauliflower-btn list-group-item list-group-item-action bg-primary text-white text-center mb-3" to='/Stories'>產地故事</Link>
                             {stories.map((item) => {
                                 return (
-                                    <Link className={`story-cauliflower-btn list-group-item list-group-item-action mb-3 ${item.id === story_id ? 'active' : ''}`} key={item.id} to={`/stories/${item.id}`}>
-                                        <span className="material-symbols-outlined align-middle fs-7">chevron_left</span>{item.title}
+                                    <Link className={`story-cauliflower-btn list-group-item list-group-item-action mb-3 d-flex align-items-center ${item.id === story_id ? 'active' : ''}`} key={item.id} to={`/stories/${item.id}`}>
+                                        <span className="material-symbols-outlined fs-4">chevron_left</span>
+                                        {item.title}
                                     </Link>)
                             })}
                         </div>
@@ -77,6 +92,7 @@ function Story() {
             </section>
         </main>
         <IsScreenLoading isScreenLoading={isScreenLoading} />
+        <Toast />
     </>
     )
 }

--- a/src/assets/pages/admin/AdminCoupons.jsx
+++ b/src/assets/pages/admin/AdminCoupons.jsx
@@ -5,7 +5,9 @@ import CouponModal from '../../component/CouponModal';
 import DeleteCouponModal from '../../component/DeleteCouponModal';
 import Toast from "../../layout/Toast";
 import { useNavigate } from 'react-router';
+import { useDispatch } from 'react-redux';
 import IsScreenLoading from '../../component/IsScreenLoading';
+import { createAsyncMessage } from '../../redux/slice/toastSlice';
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
 const apiPath = import.meta.env.VITE_API_PATH;
@@ -25,6 +27,7 @@ function AdminCoupons() {
     const modelRef = useRef(null);
     const delModelRef = useRef(null);
     const navigate = useNavigate();
+    const dispatch = useDispatch();
     const [isScreenLoading, setIsScreenLoading] = useState(false);
 
 
@@ -32,7 +35,12 @@ function AdminCoupons() {
         try {
             await axios.post(`${baseUrl}/v2/api/user/check`)
         } catch (error) {
-            alert("請登入管理員帳號", error.data.message )
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '請登入管理員帳號',
+                status: "failed"
+            }))
             navigate('/adminlogin')
         }
     }, [navigate]);
@@ -52,8 +60,18 @@ function AdminCoupons() {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/admin/coupons?page=${page}`);
             setCoupons(res.data.coupons);
             getPageInfo(res.data.pagination)
+            dispatch(createAsyncMessage({
+                text: '取得優惠卷資料成功',
+                type: '成功',
+                status: "success"
+            }))
         } catch (error) {
-            alert("請登入管理員帳號" , error.data.message)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得優惠卷資料失敗',
+                status: "failed"
+            }))
             navigate('/adminlogin')
         } finally {
             setIsScreenLoading(false)

--- a/src/assets/pages/admin/AdminOrders.jsx
+++ b/src/assets/pages/admin/AdminOrders.jsx
@@ -1,13 +1,16 @@
 import {useCallback, useEffect, useState, useRef } from 'react';
 import axios from 'axios'
 import { useNavigate } from 'react-router';
+import { useDispatch } from 'react-redux';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import IsScreenLoading from '../../component/IsScreenLoading';
 import PaginationCompo from '../../component/PaginationCompo'
 import Toast from "../../layout/Toast";
+import { createAsyncMessage } from '../../redux/slice/toastSlice';
 import OrderModal from '../../component/OrderModal';
 import FormatDate from '../../component/formatDate';
 import 'swiper/css';
+
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
 const apiPath = import.meta.env.VITE_API_PATH;
@@ -23,13 +26,19 @@ function AdminOrders() {
     const [search, setSearch] = useState('');
     const [pageInfo, getPageInfo] = useState({});
     const [searchType, setSearchType] = useState('訂單編號')
+    const dispatch = useDispatch();
 
 
     const checkLogin = useCallback(async () => {
         try {
             await axios.post(`${baseUrl}/v2/api/user/check`)
         } catch (error) {
-            alert("請登入管理員帳號", error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '請登入管理員帳號',
+                status: "failed"
+            }))
             navigate('/adminlogin')
         }
     }, [navigate]);
@@ -48,8 +57,18 @@ function AdminOrders() {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/admin/orders?page=${page}`);
             setOrders(res.data.orders)
             getPageInfo(res.data.pagination)
+            dispatch(createAsyncMessage({
+                text: '取得訂單資料成功',
+                type: '成功',
+                status: "success"
+            }))
         } catch (error) {
-            alert("取得訂單資料失敗" ,  error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得訂單資料失敗',
+                status: "failed"
+            }))
         } finally {
             setIsScreenLoading(false)
         }
@@ -105,8 +124,18 @@ function AdminOrders() {
         try {
             await axios.delete(`${baseUrl}/v2/api/${apiPath}/admin/order/${id}`)
             getOrderList()
+            dispatch(createAsyncMessage({
+                text: '刪除訂單成功',
+                type: '成功',
+                status: "success"
+            }))
         } catch (error) {
-            alert('刪除訂單失敗', error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '刪除訂單失敗',
+                status: "failed"
+            }))
         } finally {
             setIsScreenLoading(false)
         }

--- a/src/assets/pages/admin/AdminProductPage.jsx
+++ b/src/assets/pages/admin/AdminProductPage.jsx
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useState, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { Link, useNavigate } from 'react-router';
 import axios from 'axios'
 import PaginationCompo from '../../component/PaginationCompo';
 import ProductModal from '../../component/ProductModal';
 import DeleteProductModal from '../../component/DeleteProductModal';
 import Toast from "../../layout/Toast";
-import { Link, useNavigate } from 'react-router';
 import IsScreenLoading from '../../component/IsScreenLoading';
+import { createAsyncMessage } from '../../redux/slice/toastSlice';
+
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
 const apiPath = import.meta.env.VITE_API_PATH;
@@ -41,6 +44,7 @@ function AdminProductPage() {
     const [status] = useState("all"); // 當前篩選的狀態（全部 / 上架 / 未上架）
     const [isInputFocused, setIsInputFocused] = useState(false); // 控制放大鏡顯示
     const [screenWidth, setScreenWidth] = useState(window.innerWidth);
+    const dispatch = useDispatch();
 
     useEffect(() => {
         const handleResize = () => setScreenWidth(window.innerWidth);
@@ -60,8 +64,18 @@ function AdminProductPage() {
             setTotalProducts(allProducts.length);  // 計算全部商品數
             setTotalOnSale(allProducts.filter(product => product.is_enabled === 1).length); // 上架中
             setTotalNoOnSale(allProducts.filter(product => product.is_enabled === 0).length); // 未上架
+            dispatch(createAsyncMessage({
+                text: '取得所有商品數量成功',
+                type: '成功',
+                status: "success"
+            }))
         } catch (error) {
-            alert('取得所有商品數量失敗', error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得所有商品數量失敗',
+                status: "failed"
+            }))
         }
     };
 
@@ -69,7 +83,12 @@ function AdminProductPage() {
         try {
             await axios.post(`${baseUrl}/v2/api/user/check`)
         } catch (error) {
-            alert("請登入管理員帳號", error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '請登入管理員帳號',
+                status: "failed"
+            }))
             navigate('/adminlogin')
         }
     }, [navigate]);
@@ -88,8 +107,18 @@ function AdminProductPage() {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/admin/products?page=${page}`);
             setProducts(res.data.products);
             getPageInfo(res.data.pagination)
+            dispatch(createAsyncMessage({
+                text: '取得資料成功',
+                type: '成功',
+                status: "success"
+            }))
         } catch (error) {
-            alert('取得資料失敗', error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得資料失敗',
+                status: "failed"
+            }))
             navigate('/adminlogin')
         } finally {
             setIsScreenLoading(false)

--- a/src/assets/pages/admin/AdminStatistics.jsx
+++ b/src/assets/pages/admin/AdminStatistics.jsx
@@ -4,6 +4,9 @@ import IsScreenLoading from "../../component/IsScreenLoading";
 import c3 from "c3";
 import "c3/c3.css";
 import { useNavigate } from 'react-router';
+import { useDispatch } from "react-redux";
+import Toast from "../../layout/Toast";
+import { createAsyncMessage } from "../../redux/slice/toastSlice";
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
 const apiPath = import.meta.env.VITE_API_PATH;
@@ -13,6 +16,7 @@ function AdminStatistics() {
     const [productStocks, setProductStocks] = useState([]);
     const [isScreenLoading, setIsScreenLoading] = useState(false);
     const navigate = useNavigate()
+    const dispatch = useDispatch();
 
     const chartRef1 = useRef(null);
     const chartRef2 = useRef(null);
@@ -22,7 +26,12 @@ function AdminStatistics() {
         try {
             await axios.post(`${baseUrl}/v2/api/user/check`);
         } catch (error) {
-            alert("請登入管理員帳號", error.response);
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '請登入管理員帳號',
+                status: "failed"
+            }))
             navigate("/adminlogin");
         }
     }, [navigate]);
@@ -47,11 +56,20 @@ function AdminStatistics() {
             const requests = Array.from({ length: totalPages }, (_, i) =>
                 axios.get(`${baseUrl}/v2/api/${apiPath}/admin/orders?page=${i + 1}`)
             );
-
             const responses = await Promise.all(requests);
             setAllOrders(responses.flatMap((res) => res.data.orders));
+            dispatch(createAsyncMessage({
+                text: '取得訂單資料成功',
+                type: '成功',
+                status: "success"
+            }))
         } catch (error) {
-            alert("取得訂單資料失敗" ,  error.response);
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得訂單資料失敗',
+                status: "failed"
+            }))
         } finally {
             setIsScreenLoading(false);
         }
@@ -65,10 +83,19 @@ function AdminStatistics() {
                 name: product.title,
                 stock: product.product_stock
             }));
-
             setProductStocks(stocks);
+            dispatch(createAsyncMessage({
+                text: '取得商品數量成功',
+                type: '成功',
+                status: "success"
+            }))
         } catch (error) {
-            alert("取得所有商品數量失敗", error.response);
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得所有商品數量失敗',
+                status: "failed"
+            }))
         }
     };
 
@@ -165,6 +192,7 @@ function AdminStatistics() {
                 </div>
             </div>
             <IsScreenLoading isScreenLoading={isScreenLoading} />
+            <Toast />
         </main>
     );
 }

--- a/src/assets/pages/admin/AdminStory.jsx
+++ b/src/assets/pages/admin/AdminStory.jsx
@@ -5,7 +5,9 @@ import StoryModal from '../../component/StoryModal';
 import DeleteStoryModal from '../../component/DeleteStoryModal';
 import Toast from "../../layout/Toast";
 import { useNavigate } from 'react-router';
+import { useDispatch } from 'react-redux';
 import IsScreenLoading from '../../component/IsScreenLoading';
+import { createAsyncMessage } from '../../redux/slice/toastSlice';
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
 const apiPath = import.meta.env.VITE_API_PATH;
@@ -26,17 +28,23 @@ function AdminStory() {
     const [pageInfo, getPageInfo] = useState({});
     const [modalMode, setModalMode] = useState(null);
     const [tempArticle, setTempArticle] = useState(defaultModalState);
+    const [isScreenLoading, setIsScreenLoading] = useState(false)
     const modelRef = useRef(null);
     const delModelRef = useRef(null);
     const navigate = useNavigate()
-    const [isScreenLoading, setIsScreenLoading] = useState(false)
+    const dispatch = useDispatch();
 
 
     const checkLogin = useCallback(async () => {
         try {
             await axios.post(`${baseUrl}/v2/api/user/check`)
         } catch (error) {
-            alert("請登入管理員帳號", error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '請登入管理員帳號',
+                status: "failed"
+            }))
             navigate('/adminlogin')
         }
     }, [navigate]);
@@ -55,8 +63,18 @@ function AdminStory() {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/admin/articles?page=${page}`);
             setArticles(res.data.articles);
             getPageInfo(res.data.pagination)
+            dispatch(createAsyncMessage({
+                text: '取得文章成功',
+                type: '成功',
+                status: "success"
+            }))
         } catch (error) {
-            alert('取得資料失敗' ,error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得文章失敗',
+                status: "failed"
+            }))
             navigate('/adminlogin')
         } finally {
             setIsScreenLoading(false)
@@ -94,7 +112,12 @@ function AdminStory() {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/admin/article/${id}`);
             setTempArticle(res.data.article)
         } catch (error) {
-            alert('取得資料失敗', error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得資料失敗',
+                status: "failed"
+            }))
             navigate('/adminlogin')
         }
     }

--- a/src/assets/pages/member/Member.jsx
+++ b/src/assets/pages/member/Member.jsx
@@ -42,8 +42,18 @@ function Member() {
         try {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/orders`);
             setOrders(res.data.orders)
+            dispatch(createAsyncMessage({
+                text: '成功取得訂單資料',
+                type: '成功',
+                status: "success"
+            }))
         } catch (error) {
-            alert("取得訂單資料失敗", error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得訂單資料失敗',
+                status: "failed"
+            }))
         } finally {
             setIsScreenLoading(false)
         }
@@ -94,10 +104,19 @@ function Member() {
     const handleCopyCode = () => {
         navigator.clipboard.writeText(discountCode)  // 複製折扣碼到剪貼簿
             .then(() => {
-                alert("折扣碼已複製！"); // 顯示提示訊息
+                dispatch(createAsyncMessage({
+                    text: '折扣碼已複製！',
+                    type: '成功',
+                    status: "success"
+                }))
             })
             .catch((error) => {
-                alert("複製失敗！", error.response); // 顯示錯誤訊息
+                const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '複製折扣碼失敗',
+                status: "failed"
+            }))
             });
     };
     //modal

--- a/src/assets/pages/order/Cart.jsx
+++ b/src/assets/pages/order/Cart.jsx
@@ -6,6 +6,8 @@ import { useDispatch } from 'react-redux';
 import { updateCartData } from '../../redux/slice/cartSlice'
 import IsScreenLoading from "../../component/IsScreenLoading";
 import DeleteCartModal from "../../component/DeleteCartModal";
+import Toast from "../../layout/Toast";
+import { createAsyncMessage } from "../../redux/slice/toastSlice";
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
 const apiPath = import.meta.env.VITE_API_PATH;
@@ -26,7 +28,12 @@ function Cart() {
             dispatch(updateCartData(res.data.data))
             setCartList(res.data.data)
         } catch (error) {
-            alert(error.data)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得購物車資訊失敗',
+                status: "failed"
+            }))
         } finally {
             setIsScreenLoading(false)
         }
@@ -40,10 +47,20 @@ function Cart() {
     const removeCartItem = async (id) => {
         setIsScreenLoading(true)
         try {
-            await axios.delete(`${baseUrl}/v2/api/${apiPath}/cart/${id}`)
+            const res = await axios.delete(`${baseUrl}/v2/api/${apiPath}/cart/${id}`)
             getCartList()
+            dispatch(createAsyncMessage({
+                text: res.data.message,
+                type: '成功刪除品項',
+                status: "success"
+            }))
         } catch (error) {
-            alert('刪除品項失敗', error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '刪除品項失敗',
+                status: "failed"
+            }))
         } finally {
             setIsScreenLoading(false)
         }
@@ -60,7 +77,12 @@ function Cart() {
             })
             getCartList()
         } catch (error) {
-            alert('更新品項失敗', error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '更新品項失敗',
+                status: "failed"
+            }))
         } finally {
             setIsScreenLoading(false)
         }
@@ -169,7 +191,7 @@ function Cart() {
 
                         </div>
                         <aside className="col-lg-3 d-none d-lg-block">
-                            <div className="sticky-top z-0">
+                            <div className="z-0" style={{ position: 'sticky', top: '130px' }}>
                                 {filterFrozen.length > 0 ? (
                                     cartList.total >= 1000 ? (
                                         <div className="bg-secondary-200 rounded rounded-3">
@@ -343,6 +365,7 @@ function Cart() {
         </div>
         <IsScreenLoading isScreenLoading={isScreenLoading} />
         <DeleteCartModal getCartList={getCartList} delModelRef={delModelRef} />
+        <Toast />
     </>
     )
 }

--- a/src/assets/pages/order/PlaceOrder.jsx
+++ b/src/assets/pages/order/PlaceOrder.jsx
@@ -2,20 +2,29 @@ import { Link } from "react-router";
 import axios from 'axios'
 import { useDispatch } from "react-redux";
 import { useCallback, useEffect, useState } from "react";
+import { updateCartData } from '../../redux/slice/cartSlice'
+import Toast from "../../layout/Toast";
+import { createAsyncMessage } from "../../redux/slice/toastSlice";
+
 const baseUrl = import.meta.env.VITE_BASE_URL;
 const apiPath = import.meta.env.VITE_API_PATH;
-import { updateCartData } from '../../redux/slice/cartSlice'
+
 
 function PlaceOrder() {
     const [orderId, setOrderId] = useState([])
     const dispatch = useDispatch();
 
-    const getOrders = async ()=>{
+    const getOrders = async () => {
         try {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/orders`);
             setOrderId(res.data.orders)
         } catch (error) {
-            alert(error.error)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得購物車資訊失敗',
+                status: "failed"
+            }))
         }
     }
     const getCartList = useCallback(async () => {
@@ -23,7 +32,12 @@ function PlaceOrder() {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/cart`);
             dispatch(updateCartData(res.data.data))
         } catch (error) {
-            alert(error.error)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得購物車資訊失敗',
+                status: "failed"
+            }))
         }
     }, [dispatch]);
 

--- a/src/assets/pages/product/ProductBrowsingHistory.jsx
+++ b/src/assets/pages/product/ProductBrowsingHistory.jsx
@@ -9,11 +9,11 @@ function ProductBrowsingHistory({ recentProducts = [] }) {
                 <h6 className="fs-5 mb-4 text-">你曾瀏覽過：</h6>
                 <div className="d-lg-block d-flex flex-nowrap">
                     {recentProducts.map((product) => (
-                        <div className="me-lg-0 me-3" key={product.id}>
+                        <div className="me-lg-0 me-3 allProduct-catalog-card" key={product.id}>
                             <Link to={`/products/${product.category}/${product.id}`}>
                                 <img src={product.imageUrl} alt={product.title} />
-                                <div className="card-body p-2">
-                                    <h5>{product.title}</h5>
+                                <div className="card-body p-2 mb-2">
+                                    <h5 className="fs-6">{product.title}</h5>
                                 </div>
                             </Link>
                         </div>

--- a/src/assets/pages/product/ProductListAll.jsx
+++ b/src/assets/pages/product/ProductListAll.jsx
@@ -6,6 +6,9 @@ import 'swiper/css';
 import IsScreenLoading from '../../component/IsScreenLoading'
 import ProductBrowsingHistory from './ProductBrowsingHistory'
 import ProductMobileHistory from './ProductMobileHistory';
+import Toast from '../../layout/Toast';
+import { useDispatch } from 'react-redux';
+import { createAsyncMessage } from '../../redux/slice/toastSlice';
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
 const apiPath = import.meta.env.VITE_API_PATH;
@@ -20,6 +23,7 @@ function ProductListAll() {
     const location = useLocation();
     const { category } = useParams();
     const navigate = useNavigate();
+    const dispatch = useDispatch();
 
     useEffect(() => {
         const queryParams = new URLSearchParams(location.search);
@@ -39,7 +43,12 @@ function ProductListAll() {
             const res = await axios.get(`${baseUrl}/v2/api/${apiPath}/products/all`);
             setProducts(res.data.products);
         } catch (error) {
-            alert('取得資料失敗', error.response)
+            const { message } = error.response.data;
+            dispatch(createAsyncMessage({
+                text: message,
+                type: '取得資料失敗',
+                status: "failed"
+            }))
         } finally {
             setIsScreenLoading(false)
         }
@@ -143,7 +152,7 @@ function ProductListAll() {
                         />
                         <button type="submit" className="btn" style={{ display: searchQuery ? 'none' : 'block' }}  >
                             <span
-                                className="search-btn material-symbols-outlined text-primary fs-2 position-absolute top-50 translate-middle-y  me-2">
+                                className="search-btn material-symbols-outlined text-primary fs-2 position-absolute top-50 translate-middle-y pe-4">
                                 search
                             </span >
                         </button>
@@ -190,6 +199,7 @@ function ProductListAll() {
             </div>
             <ProductMobileHistory recentProducts={recentProducts} />
         </section>
+        <Toast />
     </>
     )
 }

--- a/src/assets/scss/pages/_allProduct.scss
+++ b/src/assets/scss/pages/_allProduct.scss
@@ -191,7 +191,6 @@
         }
 
         &:hover {
-            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
             transform: translateY(-4px);
         }
     }


### PR DESCRIPTION
修正以下

-可多加美化 index.html 中的 meta，例如：新增社群資訊設定（open graph Metadata）另外請多加注意 lang 要調整至相關語系，例如調整成 「zh-Hant-TW」，若是英語系網站則可以保留預設 「en」
-可統一使用 Toast 來取代原生 alert，網站視覺上會更有一致性

整體｜
-建議統一語系（都使用中文或是英文），目前產地故事的 CTA 是使用英文，建議調整為中文哩

-Navbar 建議固定於頁面頂部，方便使用者隨時切換分頁，或至少讓 Navbar 在使用者向上滾動時滑出
-數量選擇器的加減 icon 建議置中於容器中，目前偏下唷
-Search Field 右邊建議保留一些 padding，避免 icon 直接貼齊右邊

產地故事頁｜

文章列表
-文章卡片的標題建議使用 Heading 規格，以和內文做出層級之分，可以使用設計師規劃的 Ch-Title-H4（24px, font-weight 700）

-文章卡片的內文字重一般會用 Regular，有需要強調的內容才會加粗，這邊建議使用 Ch-Text-Body2（16px, font-weight 400）即可

文章內頁
-發布日期只是輔助資訊，建議視覺權重不用拉太高，字級使用 16px~20px 即可哩
右側選單的文字建議置中於按鈕中，目前偏上
選單文字與 icon 建議置中對齊
選單 icon 尺寸偏小，建議將寬高抓在 24px 左右